### PR TITLE
Update camping.py

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -58,7 +58,7 @@ def send_request(url, params):
     return resp.json()
 
 
-def get_park_information(park_id, start_date, end_date, campsite_type=None):
+def get_park_information(park_id, start_date, end_date, campsite_type=None, campsite_field=None, campsite_num=None):
     """
     This function consumes the user intent, collects the necessary information
     from the recreation.gov API, and then presents it in a nice format for the
@@ -97,6 +97,16 @@ def get_park_information(park_id, start_date, end_date, campsite_type=None):
     # Collapse the data into the described output format.
     # Filter by campsite_type if necessary.
     data = {}
+
+    campsite_num = args.campsite_num
+    campsite_type=args.campsite_type
+
+    if campsite_num != None:
+        campsite_type= args.campsite_num
+        campsite_field ="campsite_id"
+    else:
+        campsite_field= "campsite_type"
+
     for month_data in api_data:
         for campsite_id, campsite_data in month_data["campsites"].items():
             available = []
@@ -104,8 +114,10 @@ def get_park_information(park_id, start_date, end_date, campsite_type=None):
             for date, availability_value in campsite_data["availabilities"].items():
                 if availability_value != "Available":
                     continue
-                if campsite_type and campsite_type != campsite_data["campsite_type"]:
-                    continue
+                                                                                     
+                            
+                if campsite_type and campsite_type != campsite_data["{}".format(campsite_field)]:
+                   continue         
                 available.append(date)
             if available:
                 a += available
@@ -125,7 +137,7 @@ def get_num_available_sites(park_information, start_date, end_date, nights=None)
 
     num_available = 0
     num_days = (end_date - start_date).days
-    dates = [end_date - timedelta(days=i) for i in range(1, num_days + 1)]
+    dates = [end_date - timedelta(days=i) for i in range(0, num_days + 1)]
     dates = set(format_date(i, format_string=ISO_DATE_FORMAT_RESPONSE) for i in dates)
 
     if nights not in range(1, num_days + 1):
@@ -300,9 +312,13 @@ if __name__ == "__main__":
         type=positive_int,
     )
     parser.add_argument(
+        "--campsite-num",
+        help="Optional, search for availability at specific campsite #",
+    )
+    parser.add_argument(
         "--campsite-type",
         help=(
-            "If you want to filter by a type of campsite. For example "
+            "Optional, can specify type of campsite such as:"
             '"STANDARD NONELECTRIC" or TODO'
         ),
     )

--- a/camping.py
+++ b/camping.py
@@ -137,7 +137,7 @@ def get_num_available_sites(park_information, start_date, end_date, nights=None)
 
     num_available = 0
     num_days = (end_date - start_date).days
-    dates = [end_date - timedelta(days=i) for i in range(0, num_days + 1)]
+    dates = [end_date - timedelta(days=i) for i in range(1, num_days + 1)]
     dates = set(format_date(i, format_string=ISO_DATE_FORMAT_RESPONSE) for i in dates)
 
     if nights not in range(1, num_days + 1):
@@ -194,12 +194,12 @@ def consecutive_nights(available, nights):
         # Skip ranges that are too short.
         if len(r) < nights:
             continue
-        for start_index in range(0, len(r) - nights):
+        for start_index in range(0, len(r) - nights + 1):
             start_nice = format_date(
                 datetime.fromordinal(r[start_index]), format_string=INPUT_DATE_FORMAT
             )
             end_nice = format_date(
-                datetime.fromordinal(r[start_index + nights]),
+                datetime.fromordinal(r[start_index + nights - 1] + 1),
                 format_string=INPUT_DATE_FORMAT,
             )
             long_enough_consecutive_ranges.append((start_nice, end_nice))


### PR DESCRIPTION
This version adds the ability to search for availability at a specific site within a campground.  To use one specifies the campsite number (found in the specific campsite's URL on recreation.gov, ie https://www.recreation.gov/camping/campsites/[campsite-num]) in a "--campsite-num" argument.    This can be a useful feature if you want to search for availability at a favorite/specific campsite or if you are trying to find adjacent/additional availability for an existing campsite reservation.

This version also changes the starting range in ln 128 to 0 from 1 to fix a bug that prevents single day availability searches.   This change requires searches to specify dates from day of 1st night to day of last night instead of existing day of 1st night to day of check-out.   

Known issues;
- Specifying a specific campsite will only apply to a single campground, even if multiple campgrounds are specified in the "--parks" argument.  "0" results will be returned for any additional campgrounds specified when the "campsite-num" is used.
- Change to range function in ln 128 (from 1 to 0) will require users to specify start-date and end-dates on 1st and last nights, as opposed to existing 1st night and day of check-out
- Existing consecutive nights def does not properly identify all campsites with --nights X availability within a specified range.
- Readme would need to be updated if these changes were adopted